### PR TITLE
feat: add aoc-kotlin-notebook

### DIFF
--- a/adventOfCode.json
+++ b/adventOfCode.json
@@ -1,0 +1,14 @@
+{
+  "description": "Interactive Advent of Code framework for Kotlin Notebook",
+  "properties": [
+    { "name": "v", "value": "1.1.0" },
+    { "name": "v-renovate-hint", "value": "update: package=com.toldoven.aoc:aoc-kotlin-notebook" }
+  ],
+  "link": "https://github.com/Toldoven/aoc-kotlin-notebook",
+  "dependencies": [
+    "com.toldoven.aoc:aoc-kotlin-notebook:$v"
+  ],
+  "imports": [
+    "com.toldoven.aoc.notebook.*"
+  ]
+}


### PR DESCRIPTION
[`aoc-kotlin-notebook`](https://github.com/Toldoven/aoc-kotlin-notebook) — Interactive [Advent of Code](https://adventofcode.com/) framework for Kotlin Notebook.

## Description

(Briefly describe the changes you made)

## Type of change

- [X] Adding a new library descriptor
- [ ] Fixing an error in an existing descriptor
- [ ] Updating an outdated descriptor
- [ ] Updating the library version

## Checklist for new descriptors (remove if not applicable):

- [X] **Description and link** — Ensure that the `description` field accurately describes the library and that the `link` points to the current repository.
- [X] **Properties** — The `properties` field contains all versions of Maven dependecies used in the `dependencies` section.
- [X] **Dependencies** — The dependencies listed in the `dependencies` section use version variables correctly.
- [X] **Renders (if applicable)** — If the library includes classes for visualization, the `renderers` section has appropriate rendering rules.
- [X] **Testing** — Ensure that the descriptor works correctly in a Kotlin notebook.


> Please note that we reserve the right to decline PRs that add new library descriptors base on considerations of quality, stability, or long-term support.
